### PR TITLE
esm exhausted all local ports

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -88,10 +88,10 @@ type Config struct {
 	BulkSizeInMB      int    `short:"b" long:"bulk_size" description:"bulk size in MB" default:"5"`
 	ScrollTime        string `short:"t" long:"time"    description:"scroll time" default:"1m"`
 	ScrollSliceSize   int    `long:"sliced_scroll_size"    description:"size of sliced scroll, to make it work, the size should be > 1" default:"1"`
-	RecreateIndex     bool      `short:"f" long:"force"   description:"delete destination index before copying" default:"false"`
+	RecreateIndex     bool      `short:"f" long:"force"   description:"delete destination index before copying" `
 	CopyAllIndexes    bool   `short:"a" long:"all"     description:"copy indexes starting with . and _"`
-	CopyIndexSettings bool   `long:"copy_settings"          description:"copy index settings from source" default:"false"`
-	CopyIndexMappings bool   `long:"copy_mappings"          description:"copy index mappings from source" default:"false"`
+	CopyIndexSettings bool   `long:"copy_settings"          description:"copy index settings from source"`
+	CopyIndexMappings bool   `long:"copy_mappings"          description:"copy index mappings from source"`
 	ShardsCount       int    `long:"shards"            description:"set a number of shards on newly created indexes"`
 	SourceIndexNames  string `short:"x" long:"src_indexes" description:"indexes name to copy,support regex and comma separated list" default:"_all"`
 	TargetIndexName   string `short:"y" long:"dest_index" description:"indexes name to save, allow only one indexname, original indexname will be used if not specified" default:""`

--- a/domain.go
+++ b/domain.go
@@ -102,6 +102,7 @@ type Config struct {
 	SourceProxy       string    `long:"source_proxy"            description:"set proxy to source http connections, ie: http://127.0.0.1:8080"`
 	TargetProxy       string    `long:"dest_proxy"            description:"set proxy to target http connections, ie: http://127.0.0.1:8080"`
 	Refresh           bool      `long:"refresh"                 description:"refresh after migration finished"`
+	Fields            string `long:"fields"                 description:"output fields, comma separated, ie: col1,col2,col3,..." `
 
 }
 

--- a/domain.go
+++ b/domain.go
@@ -88,10 +88,10 @@ type Config struct {
 	BulkSizeInMB      int    `short:"b" long:"bulk_size" description:"bulk size in MB" default:"5"`
 	ScrollTime        string `short:"t" long:"time"    description:"scroll time" default:"1m"`
 	ScrollSliceSize   int    `long:"sliced_scroll_size"    description:"size of sliced scroll, to make it work, the size should be > 1" default:"1"`
-	RecreateIndex     bool      `short:"f" long:"force"   description:"delete destination index before copying" `
+	RecreateIndex     bool      `short:"f" long:"force"   description:"delete destination index before copying" default:"false"`
 	CopyAllIndexes    bool   `short:"a" long:"all"     description:"copy indexes starting with . and _"`
-	CopyIndexSettings bool   `long:"copy_settings"          description:"copy index settings from source"`
-	CopyIndexMappings bool   `long:"copy_mappings"          description:"copy index mappings from source"`
+	CopyIndexSettings bool   `long:"copy_settings"          description:"copy index settings from source" default:"false"`
+	CopyIndexMappings bool   `long:"copy_mappings"          description:"copy index mappings from source" default:"false"`
 	ShardsCount       int    `long:"shards"            description:"set a number of shards on newly created indexes"`
 	SourceIndexNames  string `short:"x" long:"src_indexes" description:"indexes name to copy,support regex and comma separated list" default:"_all"`
 	TargetIndexName   string `short:"y" long:"dest_index" description:"indexes name to save, allow only one indexname, original indexname will be used if not specified" default:""`

--- a/esapi.go
+++ b/esapi.go
@@ -27,7 +27,7 @@ type ESAPI interface{
 	GetIndexMappings(copyAllIndexes bool,indexNames string)(string,int,*Indexes,error)
 	UpdateIndexSettings(indexName string,settings map[string]interface{})(error)
 	UpdateIndexMapping(indexName string,mappings map[string]interface{})(error)
-	NewScroll(indexNames string,scrollTime string,docBufferCount int,query string, slicedId,maxSlicedCount int)(*Scroll, error)
+	NewScroll(indexNames string,scrollTime string,docBufferCount int,query string, slicedId,maxSlicedCount int, fields string)(*Scroll, error)
 	NextScroll(scrollTime string,scrollId string)(*Scroll,error)
 	Refresh(name string) (err error)
 }

--- a/http.go
+++ b/http.go
@@ -21,6 +21,7 @@ import (
 	"github.com/parnurzeal/gorequest"
 	log "github.com/cihub/seelog"
 	"io/ioutil"
+	"io"
 	"errors"
 	"bytes"
 	"net/url"
@@ -32,7 +33,8 @@ func Get(url string,auth *Auth,proxy string) (*http.Response, string, []error) {
 		request.SetBasicAuth(auth.User,auth.Pass)
 	}
 
-	request.Header["Content-Type"]= "application/json"
+	//request.Header["Content-Type"]= "application/json"
+	request.Header.Add("Content-Type", "application/json");
 
 	if(len(proxy)>0){
 		request.Proxy(proxy)
@@ -49,7 +51,8 @@ func Post(url string,auth *Auth, body string,proxy string)(*http.Response, strin
 		request.SetBasicAuth(auth.User,auth.Pass)
 	}
 
-	request.Header["Content-Type"]= "application/json"
+	//request.Header["Content-Type"]= "application/json"
+	request.Header.Add("Content-Type", "application/json");
 
 	if(len(proxy)>0){
 		request.Proxy(proxy)
@@ -138,6 +141,7 @@ func Request(method string,r string,auth *Auth,body *bytes.Buffer,proxy string)(
 	if err != nil {
 		return string(respBody),err
 	}
+	io.Copy(ioutil.Discard, resp.Body)
 	defer resp.Body.Close()
 	return string(respBody),nil
 }

--- a/http.go
+++ b/http.go
@@ -33,9 +33,8 @@ func Get(url string,auth *Auth,proxy string) (*http.Response, string, []error) {
 		request.SetBasicAuth(auth.User,auth.Pass)
 	}
 
-	//request.Header["Content-Type"]= "application/json"
-	request.Header.Add("Content-Type", "application/json");
-
+	request.Header["Content-Type"]= "application/json"
+	
 	if(len(proxy)>0){
 		request.Proxy(proxy)
 	}
@@ -51,9 +50,8 @@ func Post(url string,auth *Auth, body string,proxy string)(*http.Response, strin
 		request.SetBasicAuth(auth.User,auth.Pass)
 	}
 
-	//request.Header["Content-Type"]= "application/json"
-	request.Header.Add("Content-Type", "application/json");
-
+	request.Header["Content-Type"]= "application/json"
+	
 	if(len(proxy)>0){
 		request.Proxy(proxy)
 	}

--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func main() {
 		totalSize:=0;
 		finishedSlice:=0
 		for slice:=0;slice<c.ScrollSliceSize ;slice++  {
-			scroll, err := migrator.SourceESAPI.NewScroll(c.SourceIndexNames, c.ScrollTime, c.DocBufferCount, c.Query,slice,c.ScrollSliceSize)
+			scroll, err := migrator.SourceESAPI.NewScroll(c.SourceIndexNames, c.ScrollTime, c.DocBufferCount, c.Query,slice,c.ScrollSliceSize, c.Fields)
 			if err != nil {
 				log.Error(err)
 				return

--- a/v0.go
+++ b/v0.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"io/ioutil"
 	log "github.com/cihub/seelog"
 	"regexp"
 	"strings"
@@ -81,6 +83,7 @@ func (s *ESAPIV0) GetIndexSettings(indexNames string) (*Indexes, error) {
 	if errs != nil {
 		return nil, errs[0]
 	}
+	io.Copy(ioutil.Discard, resp.Body)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
@@ -105,6 +108,7 @@ func (s *ESAPIV0) GetIndexMappings(copyAllIndexes bool, indexNames string) (stri
 		log.Error(errs)
 		return "", 0, nil, errs[0]
 	}
+	io.Copy(ioutil.Discard, resp.Body)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
@@ -316,6 +320,7 @@ func (s *ESAPIV0) NewScroll(indexNames string, scrollTime string, docBufferCount
 		log.Error(errs)
 		return nil, errs[0]
 	}
+	io.Copy(ioutil.Discard, resp.Body)
 	defer resp.Body.Close()
 
 	log.Trace("new scroll,",url, body)
@@ -353,6 +358,7 @@ func (s *ESAPIV0) NextScroll(scrollTime string, scrollId string) (*Scroll, error
 		return nil, errors.New(body)
 	}
 
+	io.Copy(ioutil.Discard, resp.Body)
 	defer resp.Body.Close()
 
 	log.Trace("next scroll,",url,body)

--- a/v0.go
+++ b/v0.go
@@ -17,362 +17,373 @@ limitations under the License.
 package main
 
 import (
-	"bytes"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
-	"io/ioutil"
-	log "github.com/cihub/seelog"
-	"regexp"
-	"strings"
+        "bytes"
+        "encoding/json"
+        "errors"
+        "fmt"
+        "io"
+        "io/ioutil"
+        log "github.com/cihub/seelog"
+        "regexp"
+        "strings"
 )
 
 type ESAPIV0 struct {
-	Host      string //eg: http://localhost:9200
-	Auth      *Auth  //eg: user:pass
-	HttpProxy string //eg: http://proxyIp:proxyPort
+        Host      string //eg: http://localhost:9200
+        Auth      *Auth  //eg: user:pass
+        HttpProxy string //eg: http://proxyIp:proxyPort
 }
 
 func (s *ESAPIV0) ClusterHealth() *ClusterHealth {
 
-	url := fmt.Sprintf("%s/_cluster/health", s.Host)
-	_, body, errs := Get(url, s.Auth,s.HttpProxy)
+        url := fmt.Sprintf("%s/_cluster/health", s.Host)
+        _, body, errs := Get(url, s.Auth,s.HttpProxy)
 
-	if errs != nil {
-		return &ClusterHealth{Name: s.Host, Status: "unreachable"}
-	}
+        if errs != nil {
+                return &ClusterHealth{Name: s.Host, Status: "unreachable"}
+        }
 
-	log.Debug(url)
-	log.Debug(body)
+        log.Debug(url)
+        log.Debug(body)
 
-	health := &ClusterHealth{}
-	err := json.Unmarshal([]byte(body), health)
+        health := &ClusterHealth{}
+        err := json.Unmarshal([]byte(body), health)
 
-	if err != nil {
-		log.Error(body)
-		return &ClusterHealth{Name: s.Host, Status: "unreachable"}
-	}
-	return health
+        if err != nil {
+                log.Error(body)
+                return &ClusterHealth{Name: s.Host, Status: "unreachable"}
+        }
+        return health
 }
 
 func (s *ESAPIV0) Bulk(data *bytes.Buffer) {
-	if data == nil || data.Len() == 0 {
-		return
-	}
-	data.WriteRune('\n')
-	url := fmt.Sprintf("%s/_bulk", s.Host)
+        if data == nil || data.Len() == 0 {
+                return
+        }
+        data.WriteRune('\n')
+        url := fmt.Sprintf("%s/_bulk", s.Host)
 
-	body,err:=Request("POST",url,s.Auth,data,s.HttpProxy)
+        body,err:=Request("POST",url,s.Auth,data,s.HttpProxy)
 
-	if err != nil {
-		log.Error(err)
-		return
-	}
-	log.Trace(url,string(body))
-	data.Reset()
+        if err != nil {
+                log.Error(err)
+                return
+        }
+        log.Trace(url,string(body))
+        data.Reset()
 }
 
 func (s *ESAPIV0) GetIndexSettings(indexNames string) (*Indexes, error) {
 
-	// get all settings
-	allSettings := &Indexes{}
+        // get all settings
+        allSettings := &Indexes{}
 
-	url := fmt.Sprintf("%s/%s/_settings", s.Host, indexNames)
-	resp, body, errs := Get(url, s.Auth,s.HttpProxy)
-	if errs != nil {
-		return nil, errs[0]
-	}
-	io.Copy(ioutil.Discard, resp.Body)
-	defer resp.Body.Close()
+        url := fmt.Sprintf("%s/%s/_settings", s.Host, indexNames)
+        resp, body, errs := Get(url, s.Auth,s.HttpProxy)
+        if errs != nil {
+                return nil, errs[0]
+        }
+        io.Copy(ioutil.Discard, resp.Body)
+        defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
-		return nil, errors.New(body)
-	}
+        if resp.StatusCode != 200 {
+                return nil, errors.New(body)
+        }
 
-	log.Debug(body)
+        log.Debug(body)
 
-	err := json.Unmarshal([]byte(body), allSettings)
-	if err != nil {
-		panic(err)
-		return nil, err
-	}
+        err := json.Unmarshal([]byte(body), allSettings)
+        if err != nil {
+                panic(err)
+                return nil, err
+        }
 
-	return allSettings, nil
+        return allSettings, nil
 }
 
 func (s *ESAPIV0) GetIndexMappings(copyAllIndexes bool, indexNames string) (string, int, *Indexes, error) {
-	url := fmt.Sprintf("%s/%s/_mapping", s.Host, indexNames)
-	resp, body, errs := Get(url, s.Auth,s.HttpProxy)
-	if errs != nil {
-		log.Error(errs)
-		return "", 0, nil, errs[0]
-	}
-	io.Copy(ioutil.Discard, resp.Body)
-	defer resp.Body.Close()
+        url := fmt.Sprintf("%s/%s/_mapping", s.Host, indexNames)
+        resp, body, errs := Get(url, s.Auth,s.HttpProxy)
+        if errs != nil {
+                log.Error(errs)
+                return "", 0, nil, errs[0]
+        }
+        io.Copy(ioutil.Discard, resp.Body)
+        defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
-		return "", 0, nil, errors.New(body)
-	}
+        if resp.StatusCode != 200 {
+                return "", 0, nil, errors.New(body)
+        }
 
-	idxs := Indexes{}
-	er := json.Unmarshal([]byte(body), &idxs)
+        idxs := Indexes{}
+        er := json.Unmarshal([]byte(body), &idxs)
 
-	if er != nil {
-		log.Error(body)
-		return "", 0, nil, er
-	}
+        if er != nil {
+                log.Error(body)
+                return "", 0, nil, er
+        }
 
-	// remove indexes that start with . if user asked for it
-	if copyAllIndexes == false {
-		for name := range idxs {
-			switch name[0] {
-			case '.':
-				delete(idxs, name)
-			case '_':
-				delete(idxs, name)
+        // remove indexes that start with . if user asked for it
+        //if copyAllIndexes == false {
+        //      for name := range idxs {
+        //              switch name[0] {
+        //              case '.':
+        //                      delete(idxs, name)
+        //              case '_':
+        //                      delete(idxs, name)
+        //
+//
+//                      }
+//              }
+//      }
 
-			}
-		}
-	}
+        // if _all indexes limit the list of indexes to only these that we kept
+        // after looking at mappings
+        if indexNames == "_all" {
 
-	// if _all indexes limit the list of indexes to only these that we kept
-	// after looking at mappings
-	if indexNames == "_all" {
+                var newIndexes []string
+                for name := range idxs {
+                        newIndexes = append(newIndexes, name)
+                }
+                indexNames = strings.Join(newIndexes, ",")
 
-		var newIndexes []string
-		for name := range idxs {
-			newIndexes = append(newIndexes, name)
-		}
-		indexNames = strings.Join(newIndexes, ",")
+        } else if strings.Contains(indexNames, "*") || strings.Contains(indexNames, "?") {
 
-	} else if strings.Contains(indexNames, "*") || strings.Contains(indexNames, "?") {
+                r, _ := regexp.Compile(indexNames)
 
-		r, _ := regexp.Compile(indexNames)
+                //check index patterns
+                var newIndexes []string
+                for name := range idxs {
+                        matched := r.MatchString(name)
+                        if matched {
+                                newIndexes = append(newIndexes, name)
+                        }
+                }
+                indexNames = strings.Join(newIndexes, ",")
 
-		//check index patterns
-		var newIndexes []string
-		for name := range idxs {
-			matched := r.MatchString(name)
-			if matched {
-				newIndexes = append(newIndexes, name)
-			}
-		}
-		indexNames = strings.Join(newIndexes, ",")
+        }
 
-	}
+        i := 0
+        // wrap in mappings if moving from super old es
+        for name, idx := range idxs {
+                i++
+                if _, ok := idx.(map[string]interface{})["mappings"]; !ok {
+                        (idxs)[name] = map[string]interface{}{
+                                "mappings": idx,
+                        }
+                }
+        }
 
-	i := 0
-	// wrap in mappings if moving from super old es
-	for name, idx := range idxs {
-		i++
-		if _, ok := idx.(map[string]interface{})["mappings"]; !ok {
-			(idxs)[name] = map[string]interface{}{
-				"mappings": idx,
-			}
-		}
-	}
-
-	return indexNames, i, &idxs, nil
+        return indexNames, i, &idxs, nil
 }
 
 func getEmptyIndexSettings() map[string]interface{} {
-	tempIndexSettings := map[string]interface{}{}
-	tempIndexSettings["settings"] = map[string]interface{}{}
-	tempIndexSettings["settings"].(map[string]interface{})["index"] = map[string]interface{}{}
-	return tempIndexSettings
+        tempIndexSettings := map[string]interface{}{}
+        tempIndexSettings["settings"] = map[string]interface{}{}
+        tempIndexSettings["settings"].(map[string]interface{})["index"] = map[string]interface{}{}
+        return tempIndexSettings
 }
 
 func cleanSettings(settings map[string]interface{}) {
-	//clean up settings
-	delete(settings["settings"].(map[string]interface{})["index"].(map[string]interface{}), "creation_date")
-	delete(settings["settings"].(map[string]interface{})["index"].(map[string]interface{}), "uuid")
-	delete(settings["settings"].(map[string]interface{})["index"].(map[string]interface{}), "version")
+        //clean up settings
+        delete(settings["settings"].(map[string]interface{})["index"].(map[string]interface{}), "creation_date")
+        delete(settings["settings"].(map[string]interface{})["index"].(map[string]interface{}), "uuid")
+        delete(settings["settings"].(map[string]interface{})["index"].(map[string]interface{}), "version")
+        delete(settings["settings"].(map[string]interface{})["index"].(map[string]interface{}), "provided_name")
 }
 
 func (s *ESAPIV0) UpdateIndexSettings(name string, settings map[string]interface{}) error {
 
-	log.Debug("update index: ", name, settings)
-	cleanSettings(settings)
-	url := fmt.Sprintf("%s/%s/_settings", s.Host, name)
+        log.Debug("update index: ", name, settings)
+        cleanSettings(settings)
+        url := fmt.Sprintf("%s/%s/_settings", s.Host, name)
 
-	if _, ok := settings["settings"].(map[string]interface{})["index"]; ok {
-		if set, ok := settings["settings"].(map[string]interface{})["index"].(map[string]interface{})["analysis"]; ok {
-			log.Debug("update static index settings: ", name)
-			staticIndexSettings := getEmptyIndexSettings()
-			staticIndexSettings["settings"].(map[string]interface{})["index"].(map[string]interface{})["analysis"] = set
-			Post(fmt.Sprintf("%s/%s/_close", s.Host, name), s.Auth, "",s.HttpProxy)
-			body := bytes.Buffer{}
-			enc := json.NewEncoder(&body)
-			enc.Encode(staticIndexSettings)
-			bodyStr, err := Request("PUT", url, s.Auth, &body,s.HttpProxy)
-			if err != nil {
-				log.Error(bodyStr, err)
-				panic(err)
-				return err
-			}
-			delete(settings["settings"].(map[string]interface{})["index"].(map[string]interface{}), "analysis")
-			Post(fmt.Sprintf("%s/%s/_open", s.Host, name), s.Auth, "",s.HttpProxy)
-		}
-	}
+        if _, ok := settings["settings"].(map[string]interface{})["index"]; ok {
+                if set, ok := settings["settings"].(map[string]interface{})["index"].(map[string]interface{})["analysis"]; ok {
+                        log.Debug("update static index settings: ", name)
+                        staticIndexSettings := getEmptyIndexSettings()
+                        staticIndexSettings["settings"].(map[string]interface{})["index"].(map[string]interface{})["analysis"] = set
+                        Post(fmt.Sprintf("%s/%s/_close", s.Host, name), s.Auth, "",s.HttpProxy)
+                        body := bytes.Buffer{}
+                        enc := json.NewEncoder(&body)
+                        enc.Encode(staticIndexSettings)
+                        bodyStr, err := Request("PUT", url, s.Auth, &body,s.HttpProxy)
+                        if err != nil {
+                                log.Error(bodyStr, err)
+                                panic(err)
+                                return err
+                        }
+                        delete(settings["settings"].(map[string]interface{})["index"].(map[string]interface{}), "analysis")
+                        Post(fmt.Sprintf("%s/%s/_open", s.Host, name), s.Auth, "",s.HttpProxy)
+                }
+        }
 
-	log.Debug("update dynamic index settings: ", name)
+        log.Debug("update dynamic index settings: ", name)
 
-	body := bytes.Buffer{}
-	enc := json.NewEncoder(&body)
-	enc.Encode(settings)
-	_, err := Request("PUT", url, s.Auth, &body,s.HttpProxy)
+        body := bytes.Buffer{}
+        enc := json.NewEncoder(&body)
+        enc.Encode(settings)
+        _, err := Request("PUT", url, s.Auth, &body,s.HttpProxy)
 
-	return err
+        return err
 }
 
 func (s *ESAPIV0) UpdateIndexMapping(indexName string, settings map[string]interface{}) error {
 
-	log.Debug("start update mapping: ", indexName,settings)
+        log.Debug("start update mapping: ", indexName,settings)
 
-	for name, mapping := range settings {
+        for name, mapping := range settings {
 
-		log.Debug("start update mapping: ", indexName,name,mapping)
+                log.Debug("start update mapping: ", indexName,name,mapping)
 
-		url := fmt.Sprintf("%s/%s/%s/_mapping", s.Host, indexName, name)
+                url := fmt.Sprintf("%s/%s/%s/_mapping", s.Host, indexName, name)
 
-		body := bytes.Buffer{}
-		enc := json.NewEncoder(&body)
-		enc.Encode(mapping)
-		res, err := Request("POST", url, s.Auth, &body,s.HttpProxy)
-		if(err!=nil){
-			log.Error(url)
-			log.Error(body.String())
-			log.Error(err,res)
-			panic(err)
-		}
-	}
-	return nil
+                body := bytes.Buffer{}
+                enc := json.NewEncoder(&body)
+                enc.Encode(mapping)
+                res, err := Request("POST", url, s.Auth, &body,s.HttpProxy)
+                if(err!=nil){
+                        log.Error(url)
+                        log.Error(body.String())
+                        log.Error(err,res)
+                        panic(err)
+                }
+        }
+        return nil
 }
 
 func (s *ESAPIV0) DeleteIndex(name string) (err error) {
 
-	log.Debug("start delete index: ", name)
+        log.Debug("start delete index: ", name)
 
-	url := fmt.Sprintf("%s/%s", s.Host, name)
+        url := fmt.Sprintf("%s/%s", s.Host, name)
 
-	Request("DELETE", url, s.Auth, nil,s.HttpProxy)
+        Request("DELETE", url, s.Auth, nil,s.HttpProxy)
 
-	log.Debug("delete index: ", name)
+        log.Debug("delete index: ", name)
 
-	return nil
+        return nil
 }
 
 func (s *ESAPIV0) CreateIndex(name string, settings map[string]interface{}) (err error) {
-	cleanSettings(settings)
+        cleanSettings(settings)
 
-	body := bytes.Buffer{}
-	enc := json.NewEncoder(&body)
-	enc.Encode(settings)
-	log.Debug("start create index: ", name, settings)
+        body := bytes.Buffer{}
+        enc := json.NewEncoder(&body)
+        enc.Encode(settings)
+        log.Debug("start create index: ", name, settings)
 
-	url := fmt.Sprintf("%s/%s", s.Host, name)
+        url := fmt.Sprintf("%s/%s", s.Host, name)
 
-	resp, err := Request("PUT", url, s.Auth, &body,s.HttpProxy)
-	log.Debugf("response: %s",resp)
+        resp, err := Request("PUT", url, s.Auth, &body,s.HttpProxy)
+        log.Debugf("response: %s",resp)
 
-	return err
+        return err
 }
 
 func (s *ESAPIV0) Refresh(name string) (err error) {
 
 
-	log.Debug("refresh index: ", name)
+        log.Debug("refresh index: ", name)
 
-	url := fmt.Sprintf("%s/%s/_refresh", s.Host, name)
+        url := fmt.Sprintf("%s/%s/_refresh", s.Host, name)
 
-	Post(url,s.Auth,"",s.HttpProxy)
+        Post(url,s.Auth,"",s.HttpProxy)
 
-	return nil
+        return nil
 }
 
-func (s *ESAPIV0) NewScroll(indexNames string, scrollTime string, docBufferCount int,query string, slicedId,maxSlicedCount int) (scroll *Scroll, err error) {
+func (s *ESAPIV0) NewScroll(indexNames string, scrollTime string, docBufferCount int,query string, slicedId,maxSlicedCount int, fields string) (scroll *Scroll, err error) {
 
-	// curl -XGET 'http://es-0.9:9200/_search?search_type=scan&scroll=10m&size=50'
-	url := fmt.Sprintf("%s/%s/_search?search_type=scan&scroll=%s&size=%d", s.Host, indexNames, scrollTime, docBufferCount)
+        // curl -XGET 'http://es-0.9:9200/_search?search_type=scan&scroll=10m&size=50'
+        url := fmt.Sprintf("%s/%s/_search?search_type=scan&scroll=%s&size=%d", s.Host, indexNames, scrollTime, docBufferCount)
 
-	jsonBody:=""
-	if(len(query)>0) {
-		queryBody := map[string]interface{}{}
-		queryBody["query"] = map[string]interface{}{}
-		queryBody["query"].(map[string]interface{})["query_string"] = map[string]interface{}{}
-		queryBody["query"].(map[string]interface{})["query_string"].(map[string]interface{})["query"] = query
+        jsonBody:=""
+        if len(query) > 0 || len(fields) > 0 {
+                queryBody := map[string]interface{}{}
+                if len(fields) > 0 {
+                        if !strings.Contains(fields, ",") {
+                                log.Error("The fields shoud be seraprated by ,")
+                                return
+                        } else {
+                                queryBody["_source"] = strings.Split(fields, ",")
+                        }
+                }
 
-		jsonArray, err := json.Marshal(queryBody)
-		if (err != nil) {
-			log.Error(err)
+                if len(query) > 0 {
+                        queryBody["query"] = map[string]interface{}{}
+                        queryBody["query"].(map[string]interface{})["query_string"] = map[string]interface{}{}
+                        queryBody["query"].(map[string]interface{})["query_string"].(map[string]interface{})["query"] = query
 
-		}else{
-			jsonBody=string(jsonArray)
-		}
-	}
+                        jsonArray, err := json.Marshal(queryBody)
+                        if err != nil {
+                                log.Error(err)
 
-	resp, body, errs := Post(url, s.Auth,jsonBody,s.HttpProxy)
+                        } else {
+                                jsonBody = string(jsonArray)
+                        }
+                }
+
+        }
+        resp, body, errs := Post(url, s.Auth,jsonBody,s.HttpProxy)
 
 
 
-	if err != nil {
-		log.Error(errs)
-		return nil, errs[0]
-	}
-	io.Copy(ioutil.Discard, resp.Body)
-	defer resp.Body.Close()
+        if err != nil {
+                log.Error(errs)
+                return nil, errs[0]
+        }
+        io.Copy(ioutil.Discard, resp.Body)
+        defer resp.Body.Close()
 
-	log.Trace("new scroll,",url, body)
+        log.Trace("new scroll,",url, body)
 
-	if err != nil {
-		log.Error(err)
-		return nil, err
-	}
+        if err != nil {
+                log.Error(err)
+                return nil, err
+        }
 
-	if resp.StatusCode != 200 {
-		return nil, errors.New(body)
-	}
+        if resp.StatusCode != 200 {
+                return nil, errors.New(body)
+        }
 
-	scroll = &Scroll{}
-	err = json.Unmarshal([]byte(body), scroll)
-	if err != nil {
-		log.Error(err)
-		return nil, err
-	}
+        scroll = &Scroll{}
+        err = json.Unmarshal([]byte(body), scroll)
+        if err != nil {
+                log.Error(err)
+                return nil, err
+        }
 
-	return scroll, err
+        return scroll, err
 }
 
 func (s *ESAPIV0) NextScroll(scrollTime string, scrollId string) (*Scroll, error) {
-	//  curl -XGET 'http://es-0.9:9200/_search/scroll?scroll=5m'
-	id := bytes.NewBufferString(scrollId)
-	url := fmt.Sprintf("%s/_search/scroll?scroll=%s&scroll_id=%s", s.Host, scrollTime, id)
-	resp, body, errs := Get(url, s.Auth,s.HttpProxy)
-	if errs != nil {
-		log.Error(errs)
-		return nil, errs[0]
-	}
+        //  curl -XGET 'http://es-0.9:9200/_search/scroll?scroll=5m'
+        id := bytes.NewBufferString(scrollId)
+        url := fmt.Sprintf("%s/_search/scroll?scroll=%s&scroll_id=%s", s.Host, scrollTime, id)
+        resp, body, errs := Get(url, s.Auth,s.HttpProxy)
+        if errs != nil {
+                log.Error(errs)
+                return nil, errs[0]
+        }
 
-	if resp.StatusCode != 200 {
-		return nil, errors.New(body)
-	}
+        if resp.StatusCode != 200 {
+                return nil, errors.New(body)
+        }
 
-	io.Copy(ioutil.Discard, resp.Body)
-	defer resp.Body.Close()
+        io.Copy(ioutil.Discard, resp.Body)
+        defer resp.Body.Close()
 
-	log.Trace("next scroll,",url,body)
+        log.Trace("next scroll,",url,body)
 
-	// decode elasticsearch scroll response
-	scroll := &Scroll{}
-	err := json.Unmarshal([]byte(body), &scroll)
-	if err != nil {
-		log.Error(body)
-		log.Error(err)
-		return nil, err
-	}
+        // decode elasticsearch scroll response
+        scroll := &Scroll{}
+        err := json.Unmarshal([]byte(body), &scroll)
+        if err != nil {
+                log.Error(body)
+                log.Error(err)
+                return nil, err
+        }
 
-	return scroll, nil
+        return scroll, nil
 }
-
-

--- a/v5.go
+++ b/v5.go
@@ -22,6 +22,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"errors"
+    	"io"
+    	"io/ioutil"
 )
 
 type ESAPIV5 struct{
@@ -98,6 +100,7 @@ func (s *ESAPIV5) NewScroll(indexNames string,scrollTime string,docBufferCount i
 		log.Error(errs)
 		return nil,errs[0]
 	}
+	io.Copy(ioutil.Discard, resp.Body)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
@@ -130,6 +133,7 @@ func (s *ESAPIV5) NextScroll(scrollTime string,scrollId string)(*Scroll,error)  
 		log.Error(errs)
 		return nil,errs[0]
 	}
+	io.Copy(ioutil.Discard, resp.Body)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {


### PR DESCRIPTION
While running esm, it would exhaust all the local ports.
How to repeat：
Set parameter `-c` to 1，run esm, after 10 minutes, use  `netstat` command to check the local established connections.
```
netstat -atnp|grep ESTABLISHED|grep esm|wc -l
51566
```
After a while, esm raised lots of errors.
```
[04-13 17:51:01] [ERR] [scroll.go:49,Next] Get http://192.168.1.1:9200/_search/scroll?scroll=10m&scroll_id=DnF1ZXJ5VGhlbkZldGNoBQAAAAAITenFFm9GdnEzeUdWUVVDYS1wdUhmc0d5Z3cAAAAAag6USRZyYVVTVVZCTVRZbXBKdmE0Y2lpajR3AAAAAGoOlEgWcmFVU1VWQk1UWW1wSnZhNGNpaWo0dwAAAABnzS3JFnNhNmdBWW1hUU91OGtfTS11aHYxeUEAAAAACE3pxhZvRnZxM3lHVlFVQ2EtcHVIZnNHeWd3: dial tcp 192.168.1.2:9200: connect: cannot assign requested address
```
This is because, the default HTTP client's Transport does not attempt to reuse HTTP/1.0 or HTTP/1.1 TCP connections  ("keep-alive") unless the Body is read to completion and is closed.   And the code just calls
`resp.Body.Close()`  and the body isn't cleared.
This [paper](https://gocn.io/article/314) has details about the problem.


