### PR TITLE
Update ESM to Support Elasticsearch 7.17's Removal of Mapping Types

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -22,7 +22,6 @@ type Indexes map[string]interface{}
 
 type Document struct {
 	Index   string                 `json:"_index,omitempty"`
-	Type    string                 `json:"_type,omitempty"`
 	Id      string                 `json:"_id,omitempty"`
 	source  map[string]interface{} `json:"_source,omitempty"`
 	Routing string                 `json:"routing,omitempty"` //after 6, only `routing` was supported

--- a/migrator.go
+++ b/migrator.go
@@ -217,21 +217,14 @@ READ_DOCS:
 			}
 
 			var tempDestIndexName string
-			var tempTargetTypeName string
 			tempDestIndexName = docI["_index"].(string)
-			tempTargetTypeName = docI["_type"].(string)
 
 			if m.Config.TargetIndexName != "" {
 				tempDestIndexName = m.Config.TargetIndexName
 			}
 
-			if m.Config.OverrideTypeName != "" {
-				tempTargetTypeName = m.Config.OverrideTypeName
-			}
-
 			doc := Document{
 				Index:  tempDestIndexName,
-				Type:   tempTargetTypeName,
 				source: docI["_source"].(map[string]interface{}),
 				Id:     docI["_id"].(string),
 			}
@@ -270,7 +263,7 @@ READ_DOCS:
 			}
 
 			// sanity check
-			if len(doc.Index) == 0 || len(doc.Type) == 0 {
+			if len(doc.Index) == 0 {
 				log.Errorf("failed decoding document: %+v", doc)
 				continue
 			}
@@ -348,7 +341,6 @@ func (m *Migrator) bulkRecords(bulkOp BulkOperation, dstEsApi ESAPI, targetIndex
 		var strOperation string
 		doc := Document{
 			Index: targetIndex,
-			Type:  targetType,
 			Id:    docId, // docI["_id"].(string),
 		}
 


### PR DESCRIPTION
This pull request updates the ESM tool to ensure compatibility with Elasticsearch 7.17, which has deprecated and removed mapping types.

ref:
https://www.elastic.co/guide/en/elasticsearch/reference/7.17/removal-of-types.html